### PR TITLE
Corrected SQL Bug Where TagString Wasn't Populated

### DIFF
--- a/wheredoyouwanttoeat2.tests/Services/AdminServiceTests.cs
+++ b/wheredoyouwanttoeat2.tests/Services/AdminServiceTests.cs
@@ -47,7 +47,8 @@ namespace WhereDoYouWantToEat2.Tests.Services
                 PhoneNumber = "215.666.5543",
                 Website = "https://www.fakerestaurant.com",
                 Latitude = 0,
-                Longitude = 0
+                Longitude = 0,
+                RestaurantTags = new List<RestaurantTag>()
             };
 
             var restaurants = new List<Restaurant>();

--- a/wheredoyouwanttoeat2/Controllers/AdminController.cs
+++ b/wheredoyouwanttoeat2/Controllers/AdminController.cs
@@ -136,16 +136,6 @@ namespace WhereDoYouWantToEat2.Controllers
 
             if (restaurant != null)
             {
-                try
-                {
-                    restaurant.TagString = string.Join(',', _service.GetRestaurantTags(id).Select(rt => rt.Tag.Name).ToList());
-                }
-                catch (Exception ex)
-                {
-                    restaurant.TagString = string.Empty;
-                    _logger.LogError(ex, "Error generating tag string");
-                }
-
                 return View(restaurant);
             }
 

--- a/wheredoyouwanttoeat2/Services/AdminService.cs
+++ b/wheredoyouwanttoeat2/Services/AdminService.cs
@@ -36,7 +36,23 @@ namespace WhereDoYouWantToEat2.Services
 
         public Restaurant GetRestaurantById(int id)
         {
-            return _restaurantRepository.GetById(id);
+            var restaurant = _restaurantRepository.GetById(id);
+
+            if (restaurant == null)
+            {
+                return null;
+            }
+
+            if (restaurant.RestaurantTags.Count() > 0)
+            {
+                restaurant.TagString = string.Join(", ", restaurant.RestaurantTags.Select(rt => rt.Tag.Name).ToList());
+            }
+            else
+            {
+                restaurant.TagString = "";
+            }
+
+            return restaurant;
         }
 
         public async Task<Restaurant> AddRestaurant(Restaurant restaurant)


### PR DESCRIPTION
Corrected a bug where the tag string wasn't being populated. A datareader error was being thrown. Part of solution was adding a flag to the connections string: MultipleActiveResultSets=true.

Fixes Bug #47 